### PR TITLE
DHS88 DHS91

### DIFF
--- a/openshift-templates/automation-api-hsql/template.yml
+++ b/openshift-templates/automation-api-hsql/template.yml
@@ -50,6 +50,7 @@ objects:
           name: "${NAME}"
           ports:
           - containerPort: 8778
+            name: jolokia
             protocol: TCP
           - containerPort: 8080
             protocol: TCP
@@ -88,10 +89,6 @@ objects:
       port: 8443
       protocol: TCP
       targetPort: 8443
-    - name: 8778-tcp
-      port: 8778
-      protocol: TCP
-      targetPort: 8778
     selector:
       name: "${NAME}"
     sessionAffinity: None

--- a/openshift-templates/http-app-deploy/template.yml
+++ b/openshift-templates/http-app-deploy/template.yml
@@ -47,6 +47,7 @@ objects:
           name: "${NAME}"
           ports:
           - containerPort: 8778
+            name: jolokia
             protocol: TCP
           - containerPort: 8080
             protocol: TCP
@@ -85,10 +86,6 @@ objects:
       port: 8443
       protocol: TCP
       targetPort: 8443
-    - name: 8778-tcp
-      port: 8778
-      protocol: TCP
-      targetPort: 8778
     selector:
       name: "${NAME}"
     sessionAffinity: None


### PR DESCRIPTION
updated the application configuration templates so that the 8778 port on the container was named jolokia, and modified the service so that it is no longer exposing 8778 as this is not needed