### PR TITLE
Update Dockerfile.rhel7 to centos7

### DIFF
--- a/docker/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/docker/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -1,5 +1,5 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs8 'npm run build'"
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift/jenkins-slave-base-centos7
 
 LABEL com.redhat.component="jenkins-slave-nodejs-rhel7-docker" \
       name="openshift3/jenkins-slave-nodejs-rhel7" \


### PR DESCRIPTION
liberation-fonts package is missing in rhel7 but its available in cento7