### PR TITLE
Updated Jenkins init groovy provisioning scripts

### DIFF
--- a/s2i-config/jenkins-master/configuration/init.groovy.d/configure-shared-library.groovy
+++ b/s2i-config/jenkins-master/configuration/init.groovy.d/configure-shared-library.groovy
@@ -1,0 +1,42 @@
+import jenkins.model.Jenkins
+import jenkins.plugins.git.GitSCMSource;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+final def LOG = Logger.getLogger("LABS")
+
+def gitRepo = System.getenv('SHARED_LIB_REPO')
+
+if(gitRepo?.trim()) {
+
+  LOG.log(Level.INFO,  'Configuring shared library (implicit)...' )
+
+  def sharedLibrary = Jenkins.getInstance().getDescriptor("org.jenkinsci.plugins.workflow.libs.GlobalLibraries")
+
+  def libraryName = System.getenv('SHARED_LIB_NAME') ?: "labs-shared-library"
+  def gitRef = System.getenv('SHARED_LIB_REF') ?: "master"
+  def secretId = System.getenv('SHARED_LIB_SECRET') ?: ""
+
+  //append namespace to secret as it appears in Jenkins
+  if(secretId) {
+    secretId = System.getenv('OPENSHIFT_BUILD_NAMESPACE') + "-" + secretId
+  }
+
+  GitSCMSource source = new GitSCMSource( libraryName, gitRepo, secretId, "*", "", false);
+  SCMSourceRetriever sourceRetriever = new SCMSourceRetriever(source);
+
+  LibraryConfiguration pipeline = new LibraryConfiguration(libraryName, sourceRetriever)
+  pipeline.setDefaultVersion(gitRef)
+  pipeline.setImplicit(true)
+  sharedLibrary.get().setLibraries([pipeline])
+
+  sharedLibrary.save()
+
+  LOG.log(Level.INFO,  'Configured shared library' )
+
+} else {
+  LOG.log(Level.INFO, 'Skipping shared library configuration')
+}

--- a/s2i-config/jenkins-master/configuration/init.groovy.d/configure-sonarqube.groovy
+++ b/s2i-config/jenkins-master/configuration/init.groovy.d/configure-sonarqube.groovy
@@ -9,7 +9,6 @@ import hudson.tools.InstallSourceProperty
 
 import java.util.logging.Level
 import java.util.logging.Logger
-import static hudson.plugins.sonar.utils.SQServerVersions.SQ_5_3_OR_HIGHER
 
 final def LOG = Logger.getLogger("LABS")
 
@@ -64,8 +63,7 @@ if (rc == 200) {
 
     // Add the SonarQube server config to Jenkins
     SonarInstallation sonarInst = new SonarInstallation(
-        "sonar", sonarHost, SQ_5_3_OR_HIGHER, token, "", "", "", "", "", new TriggersConfig(), "", "", ""
-    )
+        "sonar", sonarHost, token, "", "", new TriggersConfig(), "")
     sonarConfig.setInstallations(sonarInst)
     sonarConfig.setBuildWrapperEnabled(true)
     sonarConfig.save()


### PR DESCRIPTION
The newer version of the SonarQube plugin has changed their API and so the old init provisioning scripts needed to be updated to use the newer API semantics.