### PR TITLE
Ignore errors about missing java

### DIFF
--- a/docker/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/docker/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -1,5 +1,5 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs8 'npm run build'"
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7:v3.9
 
 LABEL com.redhat.component="jenkins-slave-nodejs-rhel7-docker" \
       name="openshift3/jenkins-slave-nodejs-rhel7" \
@@ -33,7 +33,7 @@ RUN INSTALL_PKGS="rhoar-nodejs${NODEJS_VERSION} npm redhat-lsb libXScrnSaver xdg
     yum clean all -y && \
     rm -rf /var/cache/yum
 
-RUN npm install -g npm-audit-html npm-audit-ci-wrapper sonar-scanner
-RUN sonar-scanner ## Pre-execute to install dependencies
+RUN npm install --unsafe-perm -g npm-audit-html npm-audit-ci-wrapper sonar-scanner
+RUN sonar-scanner || echo ## Pre-execute to install dependencies
 
 USER 1001

--- a/docker/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/docker/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -34,6 +34,5 @@ RUN INSTALL_PKGS="rhoar-nodejs${NODEJS_VERSION} npm redhat-lsb libXScrnSaver xdg
     rm -rf /var/cache/yum
 
 RUN npm install --unsafe-perm -g npm-audit-html npm-audit-ci-wrapper sonar-scanner
-RUN sonar-scanner || echo ## Pre-execute to install dependencies
 
 USER 1001


### PR DESCRIPTION
For some reason in the Dockerfile build, sonar-scanner cannot find the Java executable, but one you run the container itself Java is there just fine, so we will skip the step of pre-caching the sonar-scanner jar file.